### PR TITLE
Add link to TALL preset

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -233,6 +233,28 @@
             </li>
           </ul>
         </div>
+        
+        <div class="mt-8 flex justify-center">
+          <div class="rounded-md bg-blue-100 p-4">
+            <div class="flex">
+              <div class="flex-shrink-0">
+                <svg class="h-5 w-5 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+                  <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+                </svg>
+              </div>
+              <div class="ml-3 flex-1 md:flex md:justify-between">
+                <p class="text-sm leading-5 text-blue-700">
+                  Want to get started quickly with the TALL stack?
+                </p>
+                <p class="mt-3 text-sm leading-5 md:mt-0 md:ml-6">
+                  <a href="https://github.com/laravel-frontend-presets/tall" class="whitespace-no-wrap font-bold text-blue-700 hover:text-blue-600 transition ease-in-out duration-150">
+                    Check out the preset &rarr;
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
This MR just adds a little info box that links to the [TALL preset](https://github.com/laravel-frontend-presets/tall), so people browsing this site have something to get them rolling with the stack.